### PR TITLE
Updated constructor arguments for Jibo SDK v1.2.2.

### DIFF
--- a/src/behaviors/mim-gui.js
+++ b/src/behaviors/mim-gui.js
@@ -7,10 +7,10 @@ import SpeakerIds from '../mim/speaker-ids.js';
 let {Status, createBehavior, factory, blackboard} = jibo.bt;
 
 module.exports = createBehavior({
-    constructor(getConfig, onStatus, onResults) {
-        this.getConfig = getConfig;
-        this.onStatus = onStatus;
-        this.onResults = onResults;
+    constructor(options) {
+        this.getConfig = options.getConfig;
+        this.onStatus = options.onStatus;
+        this.onResults = options.onResults;
         this.status = Status.INVALID;
         this.mimConfig = null;
         this.mimState = null;

--- a/src/behaviors/mim.js
+++ b/src/behaviors/mim.js
@@ -6,10 +6,10 @@ let {Status, createBehavior, factory} = jibo.bt;
 let blackboard = {};
 
 module.exports = createBehavior({
-    constructor(getConfig, onStatus, onResults) {
-        this.getConfig = getConfig;
-        this.onStatus = onStatus;
-        this.onResults = onResults;
+    constructor(options) {
+        this.getConfig = options.getConfig;
+        this.onStatus = options.onStatus;
+        this.onResults = options.onResults;
         this.status = Status.INVALID;
     },
     start() {


### PR DESCRIPTION
src/behaviors/mim.js and src/behaviors/mim-gui.js needed to have constructor arguments adjusted to use the new SDK 1.2.2 options format.